### PR TITLE
update modal include to have unique ids based on btn

### DIFF
--- a/_includes/modal.md
+++ b/_includes/modal.md
@@ -1,15 +1,23 @@
+{% comment %}
+    Bootstrap Modal, https://getbootstrap.com/docs/4.4/components/modal/
+    Options: 
+    - "button" = text of button to trigger modal
+    - "color" = color of modal button (primary, secondary, success, danger, warning, info, light, dark)
+    - "title" = header text for modal pop up
+    - "text" = body text for modal pop up, can use Markdown
+{%- endcomment -%}
 <!-- Button trigger modal -->
 <div class="text-center">
-<button type="button" class="btn btn-{{ include.color | default: 'primary' }}" data-toggle="modal" data-target="#exampleModal">
+<button type="button" class="btn btn-{{ include.color | default: 'primary' }}" data-toggle="modal" data-target="#{{ include.button | slugify }}Modal">
 {{ include.button }}
 </button>
 </div>
 <!-- Modal -->
-<div class="modal fade" id="exampleModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+<div class="modal fade" id="{{ include.button | slugify }}Modal" tabindex="-1" role="dialog" aria-labelledby="{{ include.button | slugify }}ModalLabel" aria-hidden="true">
 <div class="modal-dialog" role="document">
 <div class="modal-content">
 <div class="modal-header">
-<h5 class="modal-title" id="exampleModalLabel">{{ include.title }}</h5>
+<h5 class="modal-title" id="{{ include.button | slugify }}ModalLabel">{{ include.title }}</h5>
 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
 <span aria-hidden="true">&times;</span>
 </button>


### PR DESCRIPTION
@stapletonsl re: the issues you encountered trying to add more than one Modal to a page. This PR fixes the issue by updating the modal include code. Each modal will now generate a unique id based on the text in the button option--so you can have as many modals as you like, so long as the button text is unique.